### PR TITLE
bug/map being created in wrong order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1756,11 +1756,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "blaze": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/blaze/-/blaze-3.6.3.tgz",
-      "integrity": "sha512-6lwlZA7xKbtICKk52rJPYt+FlZo1DcL94s5VPdHjFVe3mkcw6YZhYa8uX1V7K8H5a6+namvZbp8IfZAmoRhLjA=="
-    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",

--- a/src/api/utils/buildNoJSGoogleCalendarEvents.js
+++ b/src/api/utils/buildNoJSGoogleCalendarEvents.js
@@ -19,7 +19,7 @@ function buildNoJSGoogleCalendarEvents($, title, venue) {
       .children()
       .eq(columnIndex);
 
-    const classes = correspondingTableData.attr('class') || [];
+    const classes = correspondingTableData.attr('class');
     if (!classes) { return null; }
 
     const previousMonthData = classes.indexOf('date-not-month') > -1;

--- a/src/client/components/VenueMap/index.js
+++ b/src/client/components/VenueMap/index.js
@@ -32,6 +32,7 @@ class VenueMap extends Component {
     // Durham, NC
     const mapCenter = new google.maps.LatLng(35.992729, -78.903970); // eslint-disable-line no-undef
 
+    this.addBoundsChangedListener = this.addBoundsChangedListener.bind(this);
     this.establishMapListenerCallback = this.establishMapListenerCallback.bind(this);
     this.state = {
       mapProps: {
@@ -43,11 +44,16 @@ class VenueMap extends Component {
   }
 
   componentDidMount() {
-    return navigator.geolocation.getCurrentPosition((position) => {
-      return this.updateMapPropsWithNewCoordinates(position.coords, this.addBoundsChangedListener);
-    }, () => {
-      return this.addBoundsChangedListener();
-    });
+    return navigator.geolocation.getCurrentPosition(
+      (position) => {
+        return this.updateMapPropsWithNewCoordinates(position.coords, this.addBoundsChangedListener);
+      },
+      this.addBoundsChangedListener,
+      {
+        enableHighAccuracy: true,
+        timeout: 6000
+      }
+    );
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Turns out the geolocation API isn't incredibly reliable and has incredible inconsistency across browsers/platforms. So I added a timeout which will at least force our error handler to get called when the API just shits itself.